### PR TITLE
Update Sanity GitHub Action version to v0.8-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     name: Deploy Sanity
     steps:
       - uses: actions/checkout@v2
-      - uses: sanity-io/github-action-sanity@v0.7-alpha
+      - uses: sanity-io/github-action-sanity@v0.8-alpha
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
         with:
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Export dataset
-        uses: sanity-io/github-action-sanity@v0.7-alpha
+        uses: sanity-io/github-action-sanity@v0.8-alpha
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
         with:


### PR DESCRIPTION
### Description

This pull request updates the usage of the Sanity GitHub Action in the `README.md` file to reference a newer version. Both the deploy and export workflow examples now use `sanity-io/github-action-sanity@v0.8-alpha` instead of `v0.7-alpha`, ensuring documentation reflects the latest recommended version.

Workflow documentation updates:

* Updated the Sanity deploy workflow example to use `sanity-io/github-action-sanity@v0.8-alpha` (`README.md`).
* Updated the Sanity export workflow example to use `sanity-io/github-action-sanity@v0.8-alpha` (`README.md`).